### PR TITLE
feat: compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  mongo:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: michaelfilippo
+      MONGO_INITDB_ROOT_PASSWORD: GYLxX0xDrw4ON7DM
+    ports:
+      - 27017:27017

--- a/server/db.js
+++ b/server/db.js
@@ -5,7 +5,9 @@ const MongoClient = mongodb.MongoClient;
 
 // yeah, yeah, this is terrible but this is just for training purposes so who cares?
 const MongoDbUrl =
-  "mongodb+srv://michaelfilippo:GYLxX0xDrw4ON7DM@ripassino.oupediz.mongodb.net/?retryWrites=true&w=majority&appName=sample_mflix";
+  "mongodb://michaelfilippo:GYLxX0xDrw4ON7DM@localhost:27017/?retryWrites=true&w=majority&appName=sample_mflix";
+// "mongodb+srv://michaelfilippo:GYLxX0xDrw4ON7DM@ripassino.oupediz.mongodb.net/?retryWrites=true&w=majority&appName=sample_mflix";
+// "mongodb://michaelfilippo:GYLxX0xDrw4ON7DM@localhost/?retryWrites=true&w=majority&appName=sample_mflix";
 
 let _db;
 


### PR DESCRIPTION
This pull request introduces changes to configure a local MongoDB service using Docker and updates the database connection string in the application to point to the local instance. The most important changes include adding a `mongo` service to the `compose.yaml` file and modifying the connection string in `server/db.js`.

### MongoDB Service Configuration:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR1-R9): Added a `mongo` service configuration to run a MongoDB instance locally using Docker. The service is set to always restart, uses environment variables for credentials, and exposes port `27017`.

### Database Connection Update:

* [`server/db.js`](diffhunk://#diff-faec190164d3315987d61df45930a6c96e6ad07a9a2b8e0a63e7e79d0d91153cL8-R10): Updated the `MongoDbUrl` connection string to use the local MongoDB instance (`mongodb://localhost:27017`) instead of the remote cluster. The original connection string is commented out for reference.